### PR TITLE
Fix login redirect path

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains two custom Odoo addons for managing customer signup and
 - **cloud_sas**: Provides access control utilities used by the signup process.
 
 Both addons were originally written for Odoo 16 and updated here to target Odoo 18. They have been tested on Ubuntu 24.
+In Odoo 18 the backend is now served under `/odoo` rather than `/web`, so the routes in these modules use the new prefix.
 
 ## Requirements
 

--- a/cloud_crm/controllers/signup_custom.py
+++ b/cloud_crm/controllers/signup_custom.py
@@ -196,7 +196,7 @@ class CustomSignupController(http.Controller):
 
             # Redirigir a la página de éxito
             subdomain = signup_data.get('subdomain')
-            db_url = f"https://{subdomain}.factuoo.com/web/login"
+            db_url = f"https://{subdomain}.factuoo.com/odoo/login"
             return request.render('cloud_crm.signup_success_page', {
                 'email': signup_data.get('email'),
                 'subdomain': subdomain,

--- a/cloud_sas/controllers/custom_debug.py
+++ b/cloud_sas/controllers/custom_debug.py
@@ -8,16 +8,16 @@ _logger = logging.getLogger(__name__)
 
 class CustomHome(Home):
 
-    @http.route('/web', type='http', auth="none", sitemap=False)
+    @http.route('/odoo', type='http', auth="none", sitemap=False)
     def web_client(self, s_action=None, **kw):
-        _logger.info("Accediendo a la ruta /web con session uid: %s", request.session.uid)
+        _logger.info("Accediendo a la ruta /odoo con session uid: %s", request.session.uid)
 
         # Asegurar que tenemos una base de datos y un usuario
         if not request.session.db:
-            return request.redirect('/web/database/selector')
+            return request.redirect('/odoo/database/selector')
 
         if not request.session.uid:
-            return request.redirect('/web/login', 303)
+            return request.redirect('/odoo/login', 303)
 
         if kw.get('redirect'):
             return request.redirect(kw.get('redirect'), 303)
@@ -28,7 +28,7 @@ class CustomHome(Home):
 
         # Verificar si el usuario es interno
         if not self.is_user_internal(request.session.uid):
-            return request.redirect('/web/login_successful', 303)
+            return request.redirect('/odoo/login_success', 303)
 
         # Refrescar el tiempo de vida de la sesión
         request.session.touch()
@@ -59,7 +59,7 @@ class CustomHome(Home):
             response.headers['X-Frame-Options'] = 'DENY'
             return response
         except AccessError:
-            return request.redirect('/web/login?error=access')
+            return request.redirect('/odoo/login?error=access')
 
     def is_user_internal(self, uid):
         """Determina si un usuario es interno (no es usuario portal ni público)"""


### PR DESCRIPTION
## Summary
- update login redirect route
- use `/odoo` for backend URLs on Odoo 18

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68593f6fe7e883239d134cdb376c8551