### PR TITLE
fix: improve NIF handling and SSO

### DIFF
--- a/cloud_crm/controllers/sso_login_acceptor.py
+++ b/cloud_crm/controllers/sso_login_acceptor.py
@@ -28,7 +28,7 @@ class SSOLoginController(http.Controller):
             return request.redirect("/web/login?error=invalid_token")
         user = request.env['res.users'].sudo().search([('login', '=', login)], limit=1)
         if not user:
-            return "User not found", 404
+            return request.redirect("/web/login?error=user_not_found")
 
         request.session.uid = user.id
         request.session.session_token = user._compute_session_token(request.session.sid)


### PR DESCRIPTION
## Summary
- handle Spanish NIF/CIF numbers without requiring ES prefix and surface messages in Spanish
- initialize company details in the cloned database with signup address info
- avoid invalid tuple response when SSO user is missing
- assign partner `company_type` from NIF pattern instead of formatting the VAT

## Testing
- `python -m py_compile cloud_crm/controllers/signup_custom.py cloud_crm/controllers/sso_login_acceptor.py`


------
https://chatgpt.com/codex/tasks/task_e_68c047f3452c8323a24239c785f69147