### PR TITLE
Ensure Spanish VAT prefix for signup NIF

### DIFF
--- a/cloud_crm/controllers/signup_custom.py
+++ b/cloud_crm/controllers/signup_custom.py
@@ -99,6 +99,24 @@ class CustomSignupController(http.Controller):
                 })
 
             dni = (dni or '').strip().upper()
+            if dni and not re.match(r'^[A-Z]{2}', dni):
+                dni = f'ES{dni}'
+            if dni and not dni.startswith('ES'):
+                error = "Solo se permiten NIF españoles (prefijo ES)."
+                return request.render('cloud_crm.signup_step1', {
+                    'error': error,
+                    'name': name,
+                    'email': email,
+                    'company_name': company_name,
+                    'dni': dni,
+                    'street': street,
+                    'street2': street2,
+                    'zip_id': zip_id,
+                    'zip': postal_code,
+                    'city': city,
+                    'phone': phone,
+                    'subdomain': subdomain,
+                })
             # Determinar el tipo de partner según el NIF
             try:
                 company_type = self._get_company_type(dni)


### PR DESCRIPTION
## Summary
- prepend `ES` to VAT numbers missing a country code
- derive partner type using the normalized VAT
- reject signup if VAT does not start with `ES`

## Testing
- `python -m py_compile cloud_crm/controllers/signup_custom.py`


------
https://chatgpt.com/codex/tasks/task_e_68c04f314a748323afdc61c0d5d4e2fb