### PR TITLE
Allow optional signup fields beyond name and email

### DIFF
--- a/cloud_crm/static/src/css/factuo.css
+++ b/cloud_crm/static/src/css/factuo.css
@@ -1,3 +1,34 @@
+/* Indicadores de campos obligatorios */
+.required-hint {
+    font-size: 0.875rem;
+    color: #6c757d;
+    margin-bottom: 0.5rem;
+}
+
+.required-field label {
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+    color: #0d2e57;
+}
+
+.required-field label::after {
+    content: ' *';
+    color: #dc3545;
+}
+
+.required-field .form-control {
+    border-width: 2px;
+    border-color: rgba(13, 110, 253, 0.35);
+    background: linear-gradient(180deg, rgba(13, 110, 253, 0.08), rgba(13, 110, 253, 0));
+    transition: box-shadow 0.2s ease-in-out, border-color 0.2s ease-in-out;
+}
+
+.required-field .form-control:focus {
+    border-color: #0d6efd;
+    box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+}
+
 .subdomain-group {
     display: flex;
     align-items: baseline;

--- a/cloud_crm/views/sign_up_step1.xml
+++ b/cloud_crm/views/sign_up_step1.xml
@@ -14,15 +14,17 @@
                         </div>
                     </t>
 
+                    <p class="required-hint">Completa los campos resaltados para continuar.</p>
+
                     <!-- Campo Nombre -->
-                    <div class="mb-3 field-name">
-                        <label for="name">Nombre Completo</label>
+                    <div class="mb-4 required-field field-name">
+                        <label for="name">Nombre completo</label>
                         <input type="text" name="name" id="name" required="required" class="form-control form-control-sm" t-att-value="name or ''"/>
                     </div>
 
                     <!-- Campo Email -->
-                    <div class="mb-3 field-email">
-                        <label for="email">Correo Electrónico</label>
+                    <div class="mb-4 required-field field-email">
+                        <label for="email">Correo electrónico</label>
                         <input type="email" name="email" id="email" required="required" class="form-control form-control-sm" t-att-value="email or ''"/>
                     </div>
 
@@ -35,7 +37,7 @@
                     <div class="mb-3 field-subdomain ">
                         <label for="subdomain_input">Tu acceso (modificable)</label>
                         <div class="input-group subdomain-group">
-                            <input type="text" name="subdomain" id="subdomain_input" required="required" class="form-control text-end subdomain-input" placeholder="subdominio" t-att-value="subdomain or ''"/>
+                            <input type="text" name="subdomain" id="subdomain_input" class="form-control text-end subdomain-input" placeholder="subdominio" t-att-value="subdomain or ''"/>
                             <span class="input-group-text" id="subdomain_suffix">.factuoo.com</span>
                         </div>
                         <!-- Mostrar mensaje de error específico si existe -->
@@ -47,39 +49,39 @@
                     <!-- Campo DNI -->
                     <div class="mb-3 field-dni">
                         <label for="dni">DNI</label>
-                        <input type="text" name="dni" id="dni" required="required" class="form-control form-control-sm" placeholder="00000000A" t-att-value="dni or ''"/>
+                        <input type="text" name="dni" id="dni" class="form-control form-control-sm" placeholder="00000000A" t-att-value="dni or ''"/>
                     </div>
 
-					<!-- Campo Calle -->
-					<div class="mb-3 field-street">
-						<label for="street">Calle</label>
-						<input type="text" name="street" id="street" required="required" class="form-control form-control-sm" t-att-value="street or ''"/>
-					</div>
+                    <!-- Campo Calle -->
+                    <div class="mb-3 field-street">
+                        <label for="street">Calle</label>
+                        <input type="text" name="street" id="street" class="form-control form-control-sm" t-att-value="street or ''"/>
+                    </div>
 
-					<!-- Campo Dirección 2 -->
-					<div class="mb-3 field-street2">
-						<label for="street2">Dirección 2</label>
-						<input type="text" name="street2" id="street2" class="form-control form-control-sm" t-att-value="street2 or ''"/>
-					</div>
+                    <!-- Campo Dirección 2 -->
+                    <div class="mb-3 field-street2">
+                        <label for="street2">Dirección 2</label>
+                        <input type="text" name="street2" id="street2" class="form-control form-control-sm" t-att-value="street2 or ''"/>
+                    </div>
 					
                     <!-- Campo Código Postal (con OWL) -->
                     <div class="mb-3 field-zip_id">
                         <label for="zip_id">Código Postal</label>
                         <!-- Aquí se incluye el componente OWL para el autocompletado -->
                         <!-- <div t-component="ZipAutocomplete" t-on-zip-selected="onZipSelected"/> -->
-                        <input type='text' id='zip_id' name='zip_id' class='form-control form-control-sm'/>
+                        <input type='text' id='zip_id' name='zip_id' class='form-control form-control-sm' t-att-value="zip_id or ''"/>
                     </div>
-					
-					<!-- Campo Población -->
-					<div class="mb-3 field-city">
-						<label for="city">Población</label>
-						<input type="text" name="city" id="city" required="required" class="form-control form-control-sm" t-att-value="city or ''"/>
-					</div>
-					
+
+                    <!-- Campo Población -->
+                    <div class="mb-3 field-city">
+                        <label for="city">Población</label>
+                        <input type="text" name="city" id="city" class="form-control form-control-sm" t-att-value="city or ''"/>
+                    </div>
+
                     <!-- Campo Teléfono -->
                     <div class="mb-3 field-phone">
                         <label for="phone">Teléfono</label>
-                        <input type="tel" name="phone" id="phone" required="required" class="form-control form-control-sm" t-att-value="phone or ''"/>
+                        <input type="tel" name="phone" id="phone" class="form-control form-control-sm" t-att-value="phone or ''"/>
                     </div>
 
                     <!-- Botón Enviar -->
@@ -88,7 +90,7 @@
                     </div>
                 </form>
             </div>
-			<!-- Incluir el archivo JavaScript -->
+            <!-- Incluir el archivo JavaScript -->
             <!-- <script type="text/javascript" src="/cloud_crm/static/src/js/signup_step1.js"></script> -->
 
         </t>


### PR DESCRIPTION
## Summary
- keep the original signup validations while only enforcing name and email as required inputs
- reuse any existing partner subdomain or auto-generate a unique one when the user leaves the field blank
- restore the first step form with all contact fields, marking only name and email as required and styling the required hint accordingly
- let users adjust the chosen subdomain directly from the confirmation dialog before finalizing the signup

## Testing
- python -m compileall cloud_crm

------
https://chatgpt.com/codex/tasks/task_e_68d3a4c03444832390bd357604adfe07