### PR TITLE
Align factuoo sender logic with server filter and reset provisional server creds

### DIFF
--- a/cloud_sas/__manifest__.py
+++ b/cloud_sas/__manifest__.py
@@ -2,7 +2,7 @@
     'name': "cloud_sas",
     'version': '18.0.0.0',
     'category': 'API',
-    'depends': ['base', 'web', 'account'],
+    'depends': ['base', 'web', 'account', 'mail'],
     'installable': True,
     'application': False,
     'auto_install': False,

--- a/cloud_sas/models/__init__.py
+++ b/cloud_sas/models/__init__.py
@@ -1,3 +1,5 @@
 from . import models
 from . import res_users
+from . import mail_mail
+from . import ir_mail_server
 

--- a/cloud_sas/models/ir_mail_server.py
+++ b/cloud_sas/models/ir_mail_server.py
@@ -1,0 +1,69 @@
+from odoo import models
+
+from .mail_mail import FACTUOO_DOMAIN, FACTUOO_IDENTITY
+
+
+FACTUOO_SERVER_RESET_FIELDS = {
+    "smtp_host",
+    "smtp_port",
+    "smtp_encryption",
+    "smtp_user",
+    "smtp_pass",
+    "smtp_from",
+    "from_filter",
+}
+
+
+class IrMailServer(models.Model):
+    _inherit = "ir.mail_server"
+
+    def write(self, vals):
+        factuoo_servers = self._cloud_sas_filter_factuoo_servers()
+        other_servers = self - factuoo_servers
+
+        result = True
+        if other_servers:
+            result = super(IrMailServer, other_servers).write(vals)
+
+        if factuoo_servers:
+            factuoo_vals = factuoo_servers._cloud_sas_prepare_factuoo_vals(vals)
+            factuoo_result = super(IrMailServer, factuoo_servers).write(factuoo_vals)
+            result = result and factuoo_result
+
+        return result
+
+    def _cloud_sas_prepare_factuoo_vals(self, vals):
+        factuoo_vals = vals.copy()
+        if not factuoo_vals:
+            return factuoo_vals
+
+        reset_required = False
+
+        if "smtp_from" in factuoo_vals:
+            new_from = (factuoo_vals["smtp_from"] or "").strip().lower()
+            if new_from != FACTUOO_IDENTITY:
+                reset_required = True
+
+        if "from_filter" in factuoo_vals:
+            new_filter = (factuoo_vals["from_filter"] or "").strip().lower()
+            if new_filter != FACTUOO_DOMAIN:
+                reset_required = True
+
+        if reset_required:
+            for field in FACTUOO_SERVER_RESET_FIELDS:
+                if field == "from_filter":
+                    if field not in factuoo_vals:
+                        factuoo_vals[field] = False
+                    else:
+                        current = (factuoo_vals[field] or "").strip().lower()
+                        if current == FACTUOO_DOMAIN:
+                            factuoo_vals[field] = False
+                else:
+                    factuoo_vals.setdefault(field, False)
+
+        return factuoo_vals
+
+    def _cloud_sas_filter_factuoo_servers(self):
+        return self.filtered(
+            lambda server: (server.from_filter or "").strip().lower() == FACTUOO_DOMAIN
+        )

--- a/cloud_sas/models/mail_mail.py
+++ b/cloud_sas/models/mail_mail.py
@@ -1,0 +1,81 @@
+from odoo import models, api
+
+
+FACTUOO_DOMAIN = "factuoo.com"
+FACTUOO_IDENTITY = "registro@factuoo.com"
+
+
+class MailMail(models.Model):
+    _inherit = "mail.mail"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        mails = super().create(vals_list)
+        mails._cloud_sas_force_factuoo_identity()
+        return mails
+
+    def write(self, vals):
+        if self.env.context.get("cloud_sas_skip_force_factuoo_identity"):
+            return super().write(vals)
+
+        res = super().write(vals)
+        self._cloud_sas_force_factuoo_identity()
+        return res
+
+    def _cloud_sas_force_factuoo_identity(self):
+        if not self:
+            return
+
+        if not self._cloud_sas_should_force_identity():
+            return
+
+        # At this point any dynamic email_from expression from templates has
+        # already been evaluated because we run after the base create/write
+        # logic stores the final message values.
+        factuoo_identity = FACTUOO_IDENTITY
+        lower_identity = factuoo_identity.lower()
+
+        for mail in self:
+            updates = {}
+
+            sender = (mail.email_from or "").strip()
+            if sender.lower() != lower_identity:
+                updates["email_from"] = factuoo_identity
+
+                if not (mail.reply_to or "").strip():
+                    reply_to = self._cloud_sas_get_reply_to(mail)
+                    if reply_to:
+                        updates["reply_to"] = reply_to
+
+            if updates:
+                mail.with_context(cloud_sas_skip_force_factuoo_identity=True).write(updates)
+
+    @api.model
+    def _cloud_sas_should_force_identity(self):
+        if self.env.context.get("cloud_sas_skip_force_factuoo_identity"):
+            return False
+
+        servers = self.env["ir.mail_server"].sudo().search([
+            ("active", "=", True),
+            ("from_filter", "!=", False),
+        ])
+        return any(
+            (server.from_filter or "").strip().lower() == FACTUOO_DOMAIN
+            for server in servers
+        )
+
+    @staticmethod
+    def _cloud_sas_get_reply_to(mail):
+        author = mail.author_id
+        if author:
+            reply_to = author.email_formatted or author.email
+            if reply_to:
+                return reply_to
+
+        creator_partner = mail.create_uid.partner_id if mail.create_uid else False
+        if creator_partner:
+            reply_to = creator_partner.email_formatted or creator_partner.email
+            if reply_to:
+                return reply_to
+
+        return False


### PR DESCRIPTION
## Summary
- enforce the provisional Factuoo identity whenever an active outgoing mail server is still filtered to the factuoo.com domain, ignoring the resolved template sender so provisional delivery always uses the verified address
- reset the preconfigured Factuoo SMTP credentials when the server's identity or domain filter is changed so custom settings cannot reuse the provisional account

## Testing
- python -m compileall cloud_sas/models

------
https://chatgpt.com/codex/tasks/task_e_68d3d971726083238cbad80370627148