### PR TITLE
Reset Factuoo server on any customization

### DIFF
--- a/cloud_sas/models/ir_mail_server.py
+++ b/cloud_sas/models/ir_mail_server.py
@@ -1,10 +1,10 @@
-from odoo import models
+from odoo import _, fields, models
 
 from .mail_mail import FACTUOO_DOMAIN, FACTUOO_IDENTITY
 
 
 FACTUOO_SERVER_RESET_FIELDS = {
-    name,
+    "name",
     "smtp_host",
     "smtp_port",
     "smtp_user",
@@ -36,28 +36,49 @@ class IrMailServer(models.Model):
         if not factuoo_vals:
             return factuoo_vals
 
-        reset_required = False
+        if not any(server._cloud_sas_has_factuoo_trace() for server in self):
+            return factuoo_vals
 
-        if "from_filter" in factuoo_vals:
-            new_filter = (factuoo_vals["from_filter"] or "").strip().lower()
-            if new_filter != FACTUOO_DOMAIN:
-                reset_required = True
-
-        if reset_required:
-            for field in FACTUOO_SERVER_RESET_FIELDS:
-                if field == "from_filter":
-                    if field not in factuoo_vals:
+        for field in FACTUOO_SERVER_RESET_FIELDS:
+            if field == "from_filter":
+                if field not in factuoo_vals:
+                    factuoo_vals[field] = False
+                else:
+                    current = (factuoo_vals[field] or "").strip().lower()
+                    if current == FACTUOO_DOMAIN:
                         factuoo_vals[field] = False
-                    else:
-                        current = (factuoo_vals[field] or "").strip().lower()
-                        if current == FACTUOO_DOMAIN:
-                            factuoo_vals[field] = False
+            else:
+                if field == "name":
+                    if not factuoo_vals.get(field):
+                        factuoo_vals[field] = (
+                            self._cloud_sas_generate_default_server_name()
+                        )
                 else:
                     factuoo_vals.setdefault(field, False)
 
         return factuoo_vals
 
     def _cloud_sas_filter_factuoo_servers(self):
-        return self.filtered(
-            lambda server: (server.from_filter or "").strip().lower() == FACTUOO_DOMAIN
-        )
+        return self.filtered(lambda server: server._cloud_sas_has_factuoo_trace())
+
+    def _cloud_sas_has_factuoo_trace(self):
+        self.ensure_one()
+
+        name = (self.name or "").strip().lower()
+        if name in {"factuoo", "fatuoo"}:
+            return True
+
+        if (self.from_filter or "").strip().lower() == FACTUOO_DOMAIN:
+            return True
+
+        factuoo_identity = FACTUOO_IDENTITY.lower()
+        if "smtp_user" in self._fields:
+            value = (self.smtp_user or "").strip().lower()
+            if value == factuoo_identity:
+                return True
+
+        return False
+
+    def _cloud_sas_generate_default_server_name(self):
+        timestamp = fields.Datetime.context_timestamp(self, fields.Datetime.now())
+        return _("mi servidor %s") % fields.Datetime.to_string(timestamp)


### PR DESCRIPTION
## Summary
- treat Factuoo mail servers as those still named FACTUOO/FATUOO or using the Factuoo domain/identity
- reset the provisional Factuoo configuration whenever any field is modified, assigning a fallback name when no replacement is provided
- stop intercepting writes once the server no longer carries a Factuoo trace

## Testing
- python -m compileall cloud_sas/models/ir_mail_server.py

------
https://chatgpt.com/codex/tasks/task_e_68d40b016848832399b89db3cc903897