### PR TITLE
Improve signup step 2 submission feedback

### DIFF
--- a/cloud_crm/static/src/css/factuo.css
+++ b/cloud_crm/static/src/css/factuo.css
@@ -143,3 +143,12 @@ label {
 .autocomplete-results li:hover {
     background-color: #f0f0f0;
 }
+
+body.cursor-wait,
+body.cursor-wait * {
+    cursor: progress !important;
+}
+
+button.is-processing {
+    cursor: progress !important;
+}

--- a/cloud_crm/static/src/js/signup_step2.js
+++ b/cloud_crm/static/src/js/signup_step2.js
@@ -3,9 +3,10 @@
 import publicWidget from "@web/legacy/js/public/public_widget";
 
 publicWidget.registry.ModuleSelectionStep = publicWidget.Widget.extend({
-    selector: '#signup_step2_form', 
+    selector: '#signup_step2_form',
     start: function () {
         this._bindModuleCheckboxes();
+        this._bindFormSubmission();
         return this._super.apply(this, arguments);
     },
 
@@ -27,5 +28,23 @@ publicWidget.registry.ModuleSelectionStep = publicWidget.Widget.extend({
                 $box.removeClass('selected');
             }
         }
+    },
+
+    _bindFormSubmission: function () {
+        const self = this;
+        this.$el.on('submit', function () {
+            const $submitButton = self.$('button[type="submit"]');
+            $('body').addClass('cursor-wait');
+            $submitButton.prop('disabled', true).addClass('is-processing');
+
+            window.addEventListener(
+                'pageshow',
+                function () {
+                    $('body').removeClass('cursor-wait');
+                    $submitButton.prop('disabled', false).removeClass('is-processing');
+                },
+                { once: true }
+            );
+        });
     },
 });


### PR DESCRIPTION
## Summary
- add submission handler to the step 2 form to disable the submit button and show a wait cursor while processing
- style the wait cursor state so the pointer reflects progress feedback across the page

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d4f82f3484832394e34cd331975f92