### PR TITLE
Improve signup step 2 submission feedback

### DIFF
--- a/cloud_crm/static/src/css/factuo.css
+++ b/cloud_crm/static/src/css/factuo.css
@@ -77,13 +77,61 @@
 
 /* Estilos para span dentro del label - eliminamos cualquier exceso */
 .module-box label span {
-    font-weight: normal; 
-    font-size: 14px; 
-    white-space: nowrap; 
-    text-overflow: ellipsis; 
-    overflow: hidden; 
-    display: inline-block; 
+    font-weight: normal;
+    font-size: 14px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    display: inline-block;
     width: 90%;
+}
+
+.step2-modules {
+    max-width: 960px;
+}
+
+.step2-modules h1 {
+    font-size: 1.75rem;
+}
+
+.step2-modules p {
+    font-size: 1rem;
+    margin-bottom: 0.75rem;
+}
+
+.step2-modules .module-box {
+    padding: 0.75rem 0.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.step2-modules .step2-module-row {
+    row-gap: 0.75rem;
+}
+
+.step2-modules .module-box img {
+    max-height: 45px;
+    margin-bottom: 0.5rem;
+}
+
+.step2-modules .module-label {
+    gap: 6px;
+    font-size: 0.95rem;
+    word-break: break-word;
+}
+
+.step2-modules .module-label span {
+    width: 100%;
+    white-space: normal;
+    text-align: left;
+}
+
+.step2-modules .module-label input {
+    margin-top: 0;
+}
+
+.step2-modules .btn-primary {
+    padding: 0.6rem 1.5rem;
+    font-size: 1rem;
 }
 
 h3 {
@@ -142,4 +190,13 @@ label {
 
 .autocomplete-results li:hover {
     background-color: #f0f0f0;
+}
+
+body.cursor-wait,
+body.cursor-wait * {
+    cursor: progress !important;
+}
+
+button.is-processing {
+    cursor: progress !important;
 }

--- a/cloud_crm/static/src/js/signup_step2.js
+++ b/cloud_crm/static/src/js/signup_step2.js
@@ -3,9 +3,10 @@
 import publicWidget from "@web/legacy/js/public/public_widget";
 
 publicWidget.registry.ModuleSelectionStep = publicWidget.Widget.extend({
-    selector: '#signup_step2_form', 
+    selector: '#signup_step2_form',
     start: function () {
         this._bindModuleCheckboxes();
+        this._bindFormSubmission();
         return this._super.apply(this, arguments);
     },
 
@@ -27,5 +28,23 @@ publicWidget.registry.ModuleSelectionStep = publicWidget.Widget.extend({
                 $box.removeClass('selected');
             }
         }
+    },
+
+    _bindFormSubmission: function () {
+        const self = this;
+        this.$el.on('submit', function () {
+            const $submitButton = self.$('button[type="submit"]');
+            $('body').addClass('cursor-wait');
+            $submitButton.prop('disabled', true).addClass('is-processing');
+
+            window.addEventListener(
+                'pageshow',
+                function () {
+                    $('body').removeClass('cursor-wait');
+                    $submitButton.prop('disabled', false).removeClass('is-processing');
+                },
+                { once: true }
+            );
+        });
     },
 });

--- a/cloud_crm/views/sign_up_step2.xml
+++ b/cloud_crm/views/sign_up_step2.xml
@@ -2,20 +2,20 @@
 <odoo>
     <template id="signup_step2" name="Custom Signup Step 2">
         <t t-call="website.layout">
-            <div class="container step2-modules my-5">
-                <h1 class="text-center mb-4">Registro de Usuario - Paso 2</h1>
-                <p class="text-center mb-4">Selecciona los módulos que deseas instalar en tu base de datos.</p>
+            <div class="container step2-modules my-4 py-3">
+                <h1 class="text-center mb-3">Registro de Usuario - Paso 2</h1>
+                <p class="text-center mb-3">Selecciona los módulos que deseas instalar en tu base de datos.</p>
 
                 <form t-att-action="request.httprequest.path" method="post" id="signup_step2_form">
                     <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
 
-                    <div class="row">
+                    <div class="row step2-module-row">
                         <t t-foreach="modules" t-as="module">
-                            <div class="col-md-3 col-sm-6 mb-4">
+                            <div class="col-md-3 col-sm-6 mb-3">
                                 <div class="module-box border rounded p-2 h-100 text-center">
-                                    <img t-att-src="module['icon']" alt="" class="img-fluid mb-2" style="max-height: 50px;" />
+                                    <img t-att-src="module['icon']" alt="" class="img-fluid" />
 
-                                    <label class="d-flex justify-content-center align-items-center text-wrap" style="gap: 8px; word-break: break-word;">
+                                    <label class="module-label d-flex justify-content-center align-items-center text-wrap">
                                         <input type="checkbox" name="modules" t-att-value="module['technical_name']"/>
                                         <span t-esc="module['name']" />
                                     </label>
@@ -24,7 +24,7 @@
                         </t>
                     </div>
 
-                    <div class="text-center mt-4">
+                    <div class="text-center mt-3">
                         <button type="submit" class="btn btn-primary px-4 py-2">Registrar y Crear Base de Datos</button>
                     </div>
                 </form>


### PR DESCRIPTION
## Summary
- add a submission handler to the step 2 form to disable the submit button and show a wait cursor while processing
- style the wait cursor state so the pointer reflects progress feedback across the page
- compact the paso 2 layout by tightening spacing, reducing module tile sizing, and softening heading/button proportions

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d4f82f3484832394e34cd331975f92