### PR TITLE
Handle existing subdomain databases and load step2 script

### DIFF
--- a/cloud_crm/__manifest__.py
+++ b/cloud_crm/__manifest__.py
@@ -38,6 +38,7 @@
     "assets":{       
         'web.assets_frontend':[
             'cloud_crm/static/src/js/signup_step1.js',
+            'cloud_crm/static/src/js/signup_step2.js',
             'cloud_crm/static/src/css/factuo.css',
             'cloud_crm/static/src/lib/select2/select2.css',
             'cloud_crm/static/src/lib/select2/select2.js',

--- a/cloud_crm/controllers/signup_custom.py
+++ b/cloud_crm/controllers/signup_custom.py
@@ -337,7 +337,14 @@ class CustomSignupController(http.Controller):
 
         target_db = subdomain  # Usamos el subdominio como nombre de la base de datos
         source_db = 'veri-template'  # Nombre de la base de datos predefinida a clonar
-        
+
+        if db.exp_db_exist(target_db):
+            _logger.info(
+                "La base de datos '%s' ya existe. Se reutiliza el entorno existente.",
+                target_db,
+            )
+            return
+
         # Crear el subdominio en OVH
         try:
             self.create_subdomain_in_ovh(subdomain)


### PR DESCRIPTION
## Summary
- reuse the existing environment when the requested subdomain database already exists
- include the step 2 signup script in frontend assets so the busy cursor feedback works

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d52517294083239c635089c85c3655