### PR TITLE
Derive environment reuse from partner record

### DIFF
--- a/cloud_crm/__manifest__.py
+++ b/cloud_crm/__manifest__.py
@@ -38,6 +38,7 @@
     "assets":{       
         'web.assets_frontend':[
             'cloud_crm/static/src/js/signup_step1.js',
+            'cloud_crm/static/src/js/signup_step2.js',
             'cloud_crm/static/src/css/factuo.css',
             'cloud_crm/static/src/lib/select2/select2.css',
             'cloud_crm/static/src/lib/select2/select2.js',

--- a/cloud_crm/views/signup_response.xml
+++ b/cloud_crm/views/signup_response.xml
@@ -1,12 +1,16 @@
 <template id="signup_success_page" name="Signup Success Page">
     <t t-call="website.layout">
         <div class="container">
-            <h1>¡Registro exitoso!</h1>
-            <p>Gracias por registrarte, <t t-esc="name"/>.</p>
-            <p>Tu nueva base de datos ha sido creada con éxito.</p>
+            <t t-set="is_created" t-value="creation_status == 'created'"/>
+            <h1 t-if="is_created">¡Registro exitoso!</h1>
+            <h1 t-else>¡Tu entorno ya está listo!</h1>
+            <p>Gracias por registrarte<t t-if="name">, <t t-esc="name"/></t>.</p>
+            <p t-if="is_created">Tu nueva base de datos ha sido creada con éxito.</p>
+            <p t-else>Detectamos una base de datos existente para tu subdominio y la hemos reutilizado.</p>
             <p>Puedes acceder a tu base de datos en la siguiente URL:</p>
-            <a href="db_url"><t t-esc="db_url"/></a>
-            <p>Se ha enviado un correo a <t t-esc="email"/> con instrucciones para establecer tu contraseña.</p>
+            <a t-att-href="db_url"><t t-esc="db_url"/></a>
+            <p t-if="is_created">Se ha enviado un correo a <t t-esc="email"/> con instrucciones para establecer tu contraseña.</p>
+            <p t-else>Si no recuerdas tu contraseña, puedes restablecerla desde la página de acceso.</p>
         </div>
     </t>
 </template>


### PR DESCRIPTION
## Summary
- ensure partner creation returns the created record so the signup flow can persist its identifier between steps
- repopulate the signup session without transient environment flags and re-evaluate environment reuse directly from the partner record during provisioning
- skip DNS creation when the partner already owns the requested subdomain and reuse the stored environment details when the database already exists

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d52517294083239c635089c85c3655