### PR TITLE
Adjust signup heading alignment

### DIFF
--- a/cloud_crm/static/src/css/factuo.css
+++ b/cloud_crm/static/src/css/factuo.css
@@ -210,6 +210,7 @@ body.signup-step1-body {
 .signup-step1-title {
     color: #0d2e57;
     font-weight: 600;
+    font-size: 1.35rem;
 }
 
 .signup-step1-form .signup-form-card {

--- a/cloud_crm/views/sign_up_step1.xml
+++ b/cloud_crm/views/sign_up_step1.xml
@@ -7,9 +7,11 @@
                 <div class="container">
                     <div class="row justify-content-center">
                         <div class="col-12 col-lg-10 col-xl-9">
-                            <h3 class="signup-step1-title text-center mb-4">Datos de contacto</h3>
                             <div class="row g-4 justify-content-center signup-step1-columns">
                                 <div class="col-12 col-lg-7">
+                                    <div class="text-center">
+                                        <h3 class="signup-step1-title mb-4">Datos de contacto</h3>
+                                    </div>
                                     <form id="signup_step1_form" method="post" class="signup-step1-form">
                                         <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
 


### PR DESCRIPTION
## Summary
- move the "Datos de contacto" heading inside the form column so it aligns with the form and button
- reduce the heading font size for a more compact presentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5799418c48323b004d540b980b8c8