### PR TITLE
Adjust signup step 1 button placement

### DIFF
--- a/cloud_crm/views/sign_up_step1.xml
+++ b/cloud_crm/views/sign_up_step1.xml
@@ -92,11 +92,10 @@
                                                 <label for="phone">Teléfono</label>
                                                 <input type="tel" name="phone" id="phone" class="form-control form-control-sm" t-att-value="phone or ''"/>
                                             </div>
-                                        </div>
-
-                                        <!-- Botón Enviar -->
-                                        <div class="text-center oe_login_buttons d-grid pt-3">
-                                            <button type="submit" class="btn btn-primary">Continuar al Paso 2</button>
+                                            <!-- Botón Enviar -->
+                                            <div class="text-center oe_login_buttons d-grid pt-3">
+                                                <button type="submit" class="btn btn-primary">Continuar al Paso 2</button>
+                                            </div>
                                         </div>
                                     </form>
                                 </div>


### PR DESCRIPTION
## Summary
- move the "Continuar" submission button inside the signup form card to keep it within the white panel

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d57b456c9883238fba6a534f424083