### PR TITLE
Hide CRM module from module list

### DIFF
--- a/cloud_sas/security/ir_rules.xml
+++ b/cloud_sas/security/ir_rules.xml
@@ -2,9 +2,9 @@
     <data >
 		
         <record id="rule_hide_factuoo_admin" model="ir.rule">
-            <field name="name">factuoo: Deny access to the 'cloud_sas' module</field>
+            <field name="name">factuoo: Deny access to the 'cloud_sas' and 'cloud_crm' modules</field>
             <field name="model_id" ref="base.model_ir_module_module"/>
-            <field name="domain_force">[] if user.id == 2 else [('name','!=','cloud_sas')]</field>
+            <field name="domain_force">[] if user.id == 2 else [('name', 'not in', ['cloud_sas', 'cloud_crm'])]</field>
             <field name="groups" eval="[(4, ref('base.group_user'))]"/>
             <field name="perm_read" eval="True"/>
             <field name="active" eval="False"/>


### PR DESCRIPTION
## Summary
- update the access rule so the `cloud_sas` module hides both itself and `cloud_crm`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6683081348323bf8b9681d3045302