### PR TITLE
Fix Factuoo identity detection for outgoing mails

### DIFF
--- a/cloud_sas/models/mail_mail.py
+++ b/cloud_sas/models/mail_mail.py
@@ -62,12 +62,8 @@ class MailMail(models.Model):
 
         servers = self.env["ir.mail_server"].sudo().search([
             ("active", "=", True),
-            ("from_filter", "!=", False),
         ])
-        return any(
-            (server.from_filter or "").strip().lower() == FACTUOO_DOMAIN
-            for server in servers
-        )
+        return any(server._cloud_sas_has_factuoo_trace() for server in servers)
 
     @staticmethod
     def _cloud_sas_get_reply_to(mail):


### PR DESCRIPTION
## Summary
- ensure the mail identity override checks active servers using the Factuoo trace helper so the fallback sender is always replaced

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d674b0cc188323977edbe535b35067