### PR TITLE
Refactor signup flow to avoid session state

### DIFF
--- a/cloud_crm/controllers/signup_custom.py
+++ b/cloud_crm/controllers/signup_custom.py
@@ -249,17 +249,27 @@ class CustomSignupController(http.Controller):
                         'subdomain': subdomain,
                     })
 
-            # Guardar los datos en la sesión
-            session_vals = dict(partner_vals)
-            session_vals.update({
-                'subdomain': subdomain,
-                'cloud_url': cloud_url,
-                'partner_id': partner.id if partner else None,
-            })
-            request.session['signup_data'] = session_vals
+            # Redirigir al segundo paso con la referencia del partner
+            if partner and partner.exists():
+                return request.redirect(f'/signup_step2?partner_id={partner.id}')
 
-            # Redirigir al segundo paso
-            return request.redirect('/signup_step2')
+            _logger.error(
+                "No se pudo determinar el partner tras procesar el formulario de registro"
+            )
+            return request.render('cloud_crm.signup_step1', {
+                'error': 'No se pudo guardar la información de registro. Por favor, inténtalo de nuevo.',
+                'name': name,
+                'email': email,
+                'company_name': company_name,
+                'dni': dni,
+                'street': street,
+                'street2': street2,
+                'zip_id': zip_id,
+                'zip': postal_code,
+                'city': city,
+                'phone': phone,
+                'subdomain': subdomain,
+            })
 
         else:
             # Renderizar el formulario del primer paso
@@ -273,10 +283,13 @@ class CustomSignupController(http.Controller):
         if request.httprequest.method == 'POST':
             # Obtener los módulos seleccionados
             selected_modules = request.httprequest.form.getlist('modules')
-            signup_data = request.session.get('signup_data')
+            partner_id = request.httprequest.form.get('partner_id')
 
-            if not signup_data:
+            partner = self._get_partner_from_identifier(partner_id)
+            if not partner:
                 return request.redirect('/signup_step1')
+
+            signup_data = self._prepare_signup_data_from_partner(partner)
 
             # Clonar la base de datos y crear el usuario
             try:
@@ -293,9 +306,6 @@ class CustomSignupController(http.Controller):
                     },
                 )
 
-            # Limpiar la sesión
-            request.session.pop('signup_data', None)
-
             # Redirigir a la página de éxito
             subdomain = signup_data.get('subdomain')
             creation_result = creation_result or {}
@@ -310,19 +320,79 @@ class CustomSignupController(http.Controller):
             })
 
         else:
+            partner = self._get_partner_from_identifier(kwargs.get('partner_id'))
+            if not partner:
+                return request.render('cloud_crm.signup_step1', {
+                    'error': 'No se encontró la información del registro. Por favor, completa nuevamente el formulario.'
+                })
+
             # Definir una lista fija de módulos específicos
             modules = [
                 {'name': 'Inventario', 'technical_name': 'stock', 'icon': '/cloud_crm/static/src/img/stock.svg'},
                 {'name': 'Proyectos', 'technical_name': 'project', 'icon': '/cloud_crm/static/src/img/project.svg'},
                 {'name': 'Fabricación', 'technical_name': 'mrp', 'icon': '/cloud_crm/static/src/img/mrp.svg'},
-                {'name': 'CRM/Oportunidades Cliente', 'technical_name': 'crm', 'icon': '/cloud_crm/static/src/img/crm.svg'},                  
-                {'name': 'Email Marketing', 'technical_name': 'mass_mailing', 'icon': '/cloud_crm/static/src/img/mass_mailing.svg'},            
-                {'name': 'Sitio WEB', 'technical_name': 'website', 'icon': '/cloud_crm/static/src/img/website.svg'},  
-                {'name': 'eCommerce', 'technical_name': 'website_sale', 'icon': '/cloud_crm/static/src/img/website_sale.svg'},  
+                {'name': 'CRM/Oportunidades Cliente', 'technical_name': 'crm', 'icon': '/cloud_crm/static/src/img/crm.svg'},
+
+                {'name': 'Email Marketing', 'technical_name': 'mass_mailing', 'icon': '/cloud_crm/static/src/img/mass_mailing.svg'},
+                {'name': 'Sitio WEB', 'technical_name': 'website', 'icon': '/cloud_crm/static/src/img/website.svg'},
+                {'name': 'eCommerce', 'technical_name': 'website_sale', 'icon': '/cloud_crm/static/src/img/website_sale.svg'},
             ]
 
-            return request.render('cloud_crm.signup_step2', {'modules': modules})
+            return request.render('cloud_crm.signup_step2', {
+                'modules': modules,
+                'partner_id': partner.id,
+            })
             # Renderizar el formulario del segundo paso con esta lista fija de módulos
+
+    def _get_partner_from_identifier(self, partner_ref):
+        """Obtiene un partner a partir de un identificador proporcionado."""
+
+        partner_env = request.env['res.partner'].sudo()
+
+        try:
+            partner_id = int(partner_ref)
+        except (TypeError, ValueError):
+            partner_id = False
+
+        if partner_id:
+            partner = partner_env.browse(partner_id)
+            if partner.exists():
+                return partner
+
+        if partner_ref and isinstance(partner_ref, str):
+            partner = partner_env.search([('email', '=', partner_ref.strip().lower())], limit=1)
+            if partner:
+                return partner
+
+        return False
+
+    def _prepare_signup_data_from_partner(self, partner):
+        """Construye el diccionario de datos de registro a partir de un partner."""
+
+        if not partner:
+            return {}
+
+        partner = partner.sudo()
+        subdomain = self._extract_subdomain_from_url(partner.cloud_url)
+        if not subdomain:
+            subdomain = self._generate_subdomain(partner.name, partner.email)
+        cloud_url = partner.cloud_url or (f"{subdomain}.factuoo.com" if subdomain else '')
+
+        return {
+            'partner_id': partner.id,
+            'name': partner.name,
+            'email': partner.email,
+            'company_name': (getattr(partner, 'company_name', False) or partner.name or ''),
+            'vat': partner.vat,
+            'street': partner.street,
+            'street2': partner.street2,
+            'zip': partner.zip,
+            'city': partner.city,
+            'state_id': partner.state_id.id if partner.state_id else None,
+            'phone': partner.phone,
+            'cloud_url': cloud_url,
+            'subdomain': subdomain,
+        }
 
     def create_user_and_db(self, signup_data, selected_modules):
         """

--- a/cloud_crm/views/sign_up_step2.xml
+++ b/cloud_crm/views/sign_up_step2.xml
@@ -8,6 +8,7 @@
 
                 <form t-att-action="request.httprequest.path" method="post" id="signup_step2_form">
                     <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                    <input type="hidden" name="partner_id" t-att-value="partner_id"/>
 
                     <div class="row step2-module-row">
                         <t t-foreach="modules" t-as="module">


### PR DESCRIPTION
## Summary
- redirect the first signup step to the second step using the partner id instead of storing form data in the session
- load partner information directly from the database in step 2 and add helpers plus a hidden field so provisioning relies on res.partner data only

## Testing
- python -m compileall cloud_crm/controllers/signup_custom.py

------
https://chatgpt.com/codex/tasks/task_e_68d67ab2da2c8323b4d5f33bedd662f4