### PR TITLE
Fix menu group assignment for record rules

### DIFF
--- a/cloud_sas/data/hide_record_rules_menu.xml
+++ b/cloud_sas/data/hide_record_rules_menu.xml
@@ -1,7 +1,7 @@
 <odoo>
     <data>
         <record id="base.menu_ir_rule" model="ir.ui.menu">
-            <field name="groups_id" eval="[(6, 0, [ref('cloud_sas.factuoo_admin')])]"/>
+            <field name="groups_id" eval="[(4, ref('cloud_sas.factuoo_admin'))]"/>
         </record>
     </data>
 </odoo>


### PR DESCRIPTION
## Summary
- adjust the menu group assignment to add the Factuoo Admin group without removing existing access

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3ae23c6788323b9cb08243f538af9